### PR TITLE
Light overall cleanup

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+	"private": true,
 	"dependencies": {
 		"@anthropic-ai/sdk": "^0.32.1",
 		"@playwright/test": "^1.48.2",

--- a/package.json
+++ b/package.json
@@ -1,9 +1,5 @@
 {
 	"private": true,
-	"dependencies": {
-		"@playwright/test": "^1.48.2",
-		"playwright": "^1.48.2"
-	},
 	"devDependencies": {
 		"vitest": "^2.1.4"
 	},

--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
 	"private": true,
 	"dependencies": {
-		"@anthropic-ai/sdk": "^0.32.1",
 		"@playwright/test": "^1.48.2",
 		"playwright": "^1.48.2"
 	},

--- a/package.json
+++ b/package.json
@@ -4,6 +4,8 @@
 		"vitest": "^2.1.4"
 	},
 	"scripts": {
+		"build:clean": "pnpm --filter tests-ai exec rm -rf dist",
+		"build": "pnpm --filter tests-ai build",
 		"demo:svelte-example": "pnpm --filter svelte-example run test",
 		"demo:vite-example": "pnpm --filter vite-example run test"
 	},

--- a/package.json
+++ b/package.json
@@ -5,8 +5,12 @@
 		"@playwright/test": "^1.48.2",
 		"playwright": "^1.48.2"
 	},
-	"packageManager": "pnpm@9.5.0+sha512.140036830124618d624a2187b50d04289d5a087f326c9edfc0ccd733d76c4f52c3a313d4fc148794a2a9d81553016004e6742e8cf850670268a7387fc220c903",
 	"devDependencies": {
 		"vitest": "^2.1.4"
-	}
+	},
+	"scripts": {
+		"demo:svelte-example": "pnpm --filter svelte-example run test",
+		"demo:vite-example": "pnpm --filter vite-example run test"
+	},
+	"packageManager": "pnpm@9.5.0+sha512.140036830124618d624a2187b50d04289d5a087f326c9edfc0ccd733d76c4f52c3a313d4fc148794a2a9d81553016004e6742e8cf850670268a7387fc220c903"
 }

--- a/packages/playwright/package.json
+++ b/packages/playwright/package.json
@@ -29,6 +29,7 @@
     "@anthropic-ai/sdk": "^0.32.1"
   },
   "devDependencies": {
+    "@playwright/test": "^1.48.2",
     "@types/node": "^22.9.0",
     "tsup": "^8.3.5"
   }

--- a/packages/playwright/package.json
+++ b/packages/playwright/package.json
@@ -26,11 +26,10 @@
   "author": "Jacob Zwang <zwang.jacob@gmail.com>",
   "license": "UNLICENSED",
   "dependencies": {
-    "@anthropic-ai/sdk": "^0.32.1",
-    "@types/node": "^22.9.0",
-    "dotenv": "^16.4.5"
+    "@anthropic-ai/sdk": "^0.32.1"
   },
   "devDependencies": {
+    "@types/node": "^22.9.0",
     "tsup": "^8.3.5"
   }
 }

--- a/packages/playwright/src/index.ts
+++ b/packages/playwright/src/index.ts
@@ -1,7 +1,7 @@
-import { callAnthropicComputerUse, client } from "./anthropic-call";
+import { callAnthropicComputerUse, client } from "./anthropic-call.js";
 import Anthropic from "@anthropic-ai/sdk";
-import { takeAction, ToolCall } from "../../puppeteer-tool-call/src/index";
-import { BetaTextBlock } from "@anthropic-ai/sdk/src/resources/beta/index";
+import { takeAction, ToolCall } from "../../puppeteer-tool-call/src/index.js";
+import { BetaTextBlock } from "@anthropic-ai/sdk/src/resources/beta/index.js";
 import { Page, TestType } from "@playwright/test";
 
 export const ai = async (

--- a/packages/playwright/tsconfig.json
+++ b/packages/playwright/tsconfig.json
@@ -1,8 +1,8 @@
 {
     "compilerOptions": {
-        "moduleResolution": "node",
+        "moduleResolution": "NodeNext",
         "target": "ESNext",
-        "module": "ES2022",
+        "module": "NodeNext",
         "strict": false,
         "skipLibCheck": true,
         "lib": ["ES2022", "DOM", "ESNext"],

--- a/packages/puppeteer-tool-call/package.json
+++ b/packages/puppeteer-tool-call/package.json
@@ -12,6 +12,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "playwright": "^1.48.2",
     "puppeteer": "^23.7.1"
   }
 }

--- a/packages/puppeteer-tool-call/src/index.ts
+++ b/packages/puppeteer-tool-call/src/index.ts
@@ -1,1 +1,1 @@
-export * from "./takeAction";
+export * from "./takeAction.js";

--- a/packages/puppeteer-tool-call/src/takeAction.test.ts
+++ b/packages/puppeteer-tool-call/src/takeAction.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, it, expect, vi } from "vitest";
-import { takeAction } from "./takeAction";
 import type { Page } from "playwright";
+import { takeAction } from "./takeAction.js";
 
 describe("takeAction", () => {
   let mockPage: Page;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,13 +7,6 @@ settings:
 importers:
 
   .:
-    dependencies:
-      '@playwright/test':
-        specifier: ^1.48.2
-        version: 1.48.2
-      playwright:
-        specifier: ^1.48.2
-        version: 1.48.2
     devDependencies:
       vitest:
         specifier: ^2.1.4
@@ -126,6 +119,9 @@ importers:
         specifier: ^0.32.1
         version: 0.32.1
     devDependencies:
+      '@playwright/test':
+        specifier: ^1.48.2
+        version: 1.48.2
       '@types/node':
         specifier: ^22.9.0
         version: 22.9.0
@@ -135,6 +131,9 @@ importers:
 
   packages/puppeteer-tool-call:
     dependencies:
+      playwright:
+        specifier: ^1.48.2
+        version: 1.48.2
       puppeteer:
         specifier: ^23.7.1
         version: 23.7.1(typescript@5.6.3)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -128,13 +128,10 @@ importers:
       '@anthropic-ai/sdk':
         specifier: ^0.32.1
         version: 0.32.1
+    devDependencies:
       '@types/node':
         specifier: ^22.9.0
         version: 22.9.0
-      dotenv:
-        specifier: ^16.4.5
-        version: 16.4.5
-    devDependencies:
       tsup:
         specifier: ^8.3.5
         version: 8.3.5(@swc/core@1.9.1)(jiti@1.21.6)(postcss@8.4.47)(typescript@5.6.3)(yaml@2.6.0)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,6 @@ importers:
 
   .:
     dependencies:
-      '@anthropic-ai/sdk':
-        specifier: ^0.32.1
-        version: 0.32.1
       '@playwright/test':
         specifier: ^1.48.2
         version: 1.48.2


### PR DESCRIPTION
### Description 

This PR doesn't change any core functionalities or the behavior of the project, however it does clean some things a bit:

- It setup TypeScript for modern version of node.js (the node moduleResolution is mainly node <= node@16)
- It removes some top-level dependencies to place them in the workspaces that uses them
- It surface some top-level scripts to quickly build and run the demos

I've tested to run the following commands without any issue:

```sh
pnpm build
pnpm build:clean
pnpm demo:vite-example
pnpm demo:svelte-example
```

I am creating a PR so that it can be reviewed and tested on some other workstations instead of pushing on main directly